### PR TITLE
fix: load-more page param always read as 0 (float coercion)

### DIFF
--- a/Gebruederheitz/WpAsyncPostsProvider/AsyncPosts.php
+++ b/Gebruederheitz/WpAsyncPostsProvider/AsyncPosts.php
@@ -48,13 +48,12 @@ class AsyncPosts implements AsyncPostsInterface
 
         $rawPageParameter = $request->get_param('page');
 
-        if (is_string($rawPageParameter)) {
-            $pageNumber = intval($rawPageParameter);
-        } elseif (is_int($rawPageParameter)) {
-            $pageNumber = $rawPageParameter;
-        } else {
-            $pageNumber = 0;
-        }
+        // The 'page' parameter may arrive as an int, a numeric string, or –
+        // after sanitize_params() coerces the 'integer'/'number' schema type –
+        // as a float. Accept any numeric value; everything else is page 0.
+        $pageNumber = is_numeric($rawPageParameter)
+            ? intval($rawPageParameter)
+            : 0;
 
         $returnType = $request->get_param('return');
         $templateUsed = $request->get_param('partial') ?: '';
@@ -122,7 +121,8 @@ class AsyncPosts implements AsyncPostsInterface
                         'page' => [
                             'description' => 'Which page to show',
                             'default' => 0,
-                            'type' => 'number',
+                            'type' => 'integer',
+                            'sanitize_callback' => 'absint',
                         ],
                         'return' => [
                             'description' =>


### PR DESCRIPTION
## Problem

The "load more" REST endpoint (`/posts/load-more`) returns the **same first page of posts on every request**. Subsequent pages never advance.

## Root cause

In `AsyncPosts::restGetPaginatedPosts`:

1. The `page` arg is declared with schema `'type' => 'number'`.
2. `$request->sanitize_params()` coerces it per schema → a numeric string `"2"` becomes **`float(2)`**.
3. The handler only branches on `is_string()` / `is_int()`:

```php
if (is_string($rawPageParameter)) { ... }
elseif (is_int($rawPageParameter)) { ... }
else { $pageNumber = 0; }   // float lands here → always 0
```

So `$pageNumber` is reset to `0` on every call, and `getPaginatedPostsData` always runs the page-0 branch.

Verified: `var_dump` of the sanitized param yields `float(2)`, with `is_int=false` and `is_string=false`.

## Fix

- Accept any numeric value: `$pageNumber = is_numeric($raw) ? intval($raw) : 0;`
- Declare the arg as `'integer'` with an `absint` `sanitize_callback` so it arrives as a proper int.

🤖 Generated with [Claude Code](https://claude.com/claude-code)